### PR TITLE
chore(fix): npm token reference

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,4 +37,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+        run: |
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+          npx semantic-release


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/publish.yml` file to enhance the security and reliability of the NPM publishing process.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L40-R42): Modified the `run` command to include writing the NPM authentication token to `.npmrc` before running `npx semantic-release`.